### PR TITLE
Changed the order of image and container removal.

### DIFF
--- a/build3/Dockerfile
+++ b/build3/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.8
+
+ADD . /go/src/app
+
+CMD ["go", "run", "/go/src/app/main.go"]
+

--- a/build3/main.go
+++ b/build3/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/build5/curlcontainer2/Dockerfile
+++ b/build5/curlcontainer2/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu
+FROM debian:stretch
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update -y && apt-get install -y \
   curl \
   pv \
   iputils-ping \

--- a/module2.md
+++ b/module2.md
@@ -40,8 +40,8 @@ In this exercise you will become familiar with the docker commit command which a
 7. Type ```docker images``` and note that you now see two images one name harry with a tag of latest and another named harry with a tag of potter
 8. Type ```docker run -ti --name harry harry:potter``` and type ```ls``` to note that the ron_was_here.txt file is in the new container
 9. Type exit
-10. Type ```docker rmi harry:potter```
-11. Type ```docker rm harry```
+10. Type ```docker rm harry```
+11. Type ```docker rmi harry:potter```
 
 Although this example is simple the idea here is to see how you take a container, add new configurations to it and make and image from it to be used in other containers. However, as useful as docker commit is ultimately you will most likely use it rarely and instead will favor the Dockerfile process to build your images. Using docker commit is typically a one time process where you have to create the first container to make the next image. A Dockerfile is a more consistent way to make repeatable images or new images with changes to the Dockerfile options.
 


### PR DESCRIPTION
When I ran `docker rmi harry:potter`, I received an error stating the
image was referenced by a container.  Running `docker rm harry`
beforehand, however, removes the container and allows for the initial
command to execute successfully.